### PR TITLE
Fix CSP to work in recent versions of Chromium

### DIFF
--- a/redirector/manifest.json
+++ b/redirector/manifest.json
@@ -10,5 +10,5 @@
     "webRequest",
     "webRequestBlocking"
   ],
-  "content_security_policy": "script-src 'self' https://*.googleapis.com https://*.bootstrapcdn.com; object-src 'self'"
+  "content_security_policy": "script-src 'self' https://ajax.googleapis.com https://netdna.bootstrapcdn.com; object-src 'self'"
 }


### PR DESCRIPTION
Fixes the error "'content_security_policy': Ignored insecure CSP value "https://*.googleapis.com" in directive 'script-src'."

![image](https://github.com/LoganDark/chrome-extension-redirector/assets/4723091/06dacd4c-0402-4cb5-b283-31fede6696c5)

Fixes jQuery not loading on the options page.

![image](https://github.com/LoganDark/chrome-extension-redirector/assets/4723091/f99a8d56-400b-43b2-8901-ae4c030da2a8)

Fixes none of the buttons or functionality working (due to the missing jQuery).